### PR TITLE
feat(domain): Add JPA annotations to CarSupplier, Incident, and SecurityCompany entities

### DIFF
--- a/src/main/java/za/co/rideloop/Domain/CarSupplier.java
+++ b/src/main/java/za/co/rideloop/Domain/CarSupplier.java
@@ -2,6 +2,7 @@ package za.co.rideloop.Domain;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 import java.util.Date;
 import java.util.Objects;
@@ -10,13 +11,14 @@ import java.util.Objects;
  * RideLoop
  * CarSupplier.java
  *
- * @author : Swatsi Bongani Ratia
- * @studnr : 230724477
- * @group : 3I
- * @date : 5/12/2025
- * @Java version: "21.0.3" 2024-04-16 LTS
+ * author : Swatsi Bongani Ratia
+ * studnr : 230724477
+ * group : 3I
+ * date : 5/12/2025
+ * Java version: "21.0.3" 2024-04-16 LTS
  */
 @Entity
+@Table(name="CarSupplier")
 public class CarSupplier {
     @Id
     private int supplierID;

--- a/src/main/java/za/co/rideloop/Domain/Incident.java
+++ b/src/main/java/za/co/rideloop/Domain/Incident.java
@@ -1,6 +1,7 @@
 package za.co.rideloop.Domain;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 import java.util.Objects;
 
@@ -8,13 +9,14 @@ import java.util.Objects;
  * RideLoop
  * Incident.java
  *
- * @author : Swatsi Bongani Ratia
- * @studnr : 230724477
- * @group : 3I
- * @date : 5/10/2025
- * @Java version: "21.0.3" 2024-04-16 LTS
+ * author : Swatsi Bongani Ratia
+ * studnr : 230724477
+ * group : 3I
+ * date : 5/10/2025
+ * Java version: "21.0.3" 2024-04-16 LTS
  */
 @Entity
+@Table(name="Incident")
 public class Incident {
     @Id
     private int incidentID;

--- a/src/main/java/za/co/rideloop/Domain/SecurityCompany.java
+++ b/src/main/java/za/co/rideloop/Domain/SecurityCompany.java
@@ -2,6 +2,7 @@ package za.co.rideloop.Domain;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 import java.util.Date;
 import java.util.Objects;
@@ -10,13 +11,14 @@ import java.util.Objects;
  * RideLoop
  * SecurityCompany.java
  *
- * @author : Swatsi Bongani Ratia
- * @studnr : 230724477
- * @group : 3I
- * @date : 5/12/2025
- * @Java version: "21.0.3" 2024-04-16 LTS
+ * author : Swatsi Bongani Ratia
+ * studnr : 230724477
+ * group : 3I
+ * date : 5/12/2025
+ * Java version: "21.0.3" 2024-04-16 LTS
  */
 @Entity
+@Table(name="SecurityCompany")
 public class SecurityCompany {
     @Id
     private int securityCompanyID;

--- a/src/main/java/za/co/rideloop/Repository/CarSupplierRepository.java
+++ b/src/main/java/za/co/rideloop/Repository/CarSupplierRepository.java
@@ -1,0 +1,18 @@
+package za.co.rideloop.Repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import za.co.rideloop.Domain.CarSupplier;
+
+/**
+ * RideLoop
+ * CarSupplier.java
+ * <p>
+ * author : Swatsi Bongani Ratia
+ * studnr : 230724477
+ * group : 3I
+ * date : 5/24/2025
+ * Java version: "21.0.3" 2024-04-16 LTS
+ */
+public interface CarSupplierRepository extends JpaRepository<CarSupplier, Integer> {
+
+}

--- a/src/main/java/za/co/rideloop/Repository/IncidentRepository.java
+++ b/src/main/java/za/co/rideloop/Repository/IncidentRepository.java
@@ -1,0 +1,18 @@
+package za.co.rideloop.Repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import za.co.rideloop.Domain.Incident;
+
+/**
+ * RideLoop
+ * IncidentRepository.java
+ * <p>
+ * author : Swatsi Bongani Ratia
+ * studnr : 230724477
+ * group : 3I
+ * date : 5/24/2025
+ * Java version: "21.0.3" 2024-04-16 LTS
+ */
+public interface IncidentRepository extends JpaRepository<Incident, Integer> {
+
+}

--- a/src/main/java/za/co/rideloop/Repository/SecurityCompanyRepository.java
+++ b/src/main/java/za/co/rideloop/Repository/SecurityCompanyRepository.java
@@ -1,0 +1,18 @@
+package za.co.rideloop.Repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import za.co.rideloop.Domain.SecurityCompany;
+
+/**
+ * RideLoop
+ * SecurityCompanyRepository.java
+ * <p>
+ * author : Swatsi Bongani Ratia
+ * studnr : 230724477
+ * group : 3I
+ * date : 5/24/2025
+ * Java version: "21.0.3" 2024-04-16 LTS
+ */
+public interface SecurityCompanyRepository extends JpaRepository<SecurityCompany, Integer> {
+
+}


### PR DESCRIPTION
### Summary
This PR introduces JPA annotations to the following domain classes to align them with the database schema and support ORM integration:

- `CarSupplier.java`
- `Incident.java`
- `SecurityCompany.java`

### Details
- Annotated each class with `@Entity` and `@Table(name = "...")` to define table mappings.
- Specified primary keys using `@Id`.
- Ensured constructors and Builder patterns remain intact.
- Classes follow immutability principles where applicable (e.g., copying mutable Date fields).
- Ensured annotations do not conflict with other unannotated classes in the project.

### Why?
This is part of Issue #107 which tracks entity-to-table mapping standardization. These annotations are essential for Hibernate/JPA to recognize and manage entity persistence.

### Linked Issue
Fixes #107

### Reviewer Notes
- Please verify table names match DB schema.
- Ensure Builder pattern compatibility is unaffected.
- No logic or business rules were modified.

---